### PR TITLE
Fix missing properties on client and methods

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,10 @@
  */
 function promisify(client) {
   Object.keys(Object.getPrototypeOf(client)).forEach(functionName => {
+    // Members starting with '$' are internal only, gRPC methods cannot start with '$'
+    if (functionName.startsWith('$')) {
+      return;
+    }
     const originalFunction = client[functionName];
 
     client[functionName] = (request, callback) => {
@@ -28,6 +32,8 @@ function promisify(client) {
         });
       });
     };
+    // Reattach the client interceptors
+    client[functionName].interceptors = originalFunction.interceptors;
   });
 }
 


### PR DESCRIPTION
Starting with gRPC 1.11, users get a `TypeError: Cannot read property 'concat' of null` because grpc-promisify is not retaining internal properties of the client and does not reattach properties of the client methods.

Confirmed that this fix works with the greeter_client.js example on gRPC 1.11.x https://github.com/grpc/grpc/blob/master/examples/node/dynamic_codegen/greeter_client.js