### PR TITLE
pass options to underlying client

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,15 +11,23 @@ function promisify(client) {
   Object.keys(Object.getPrototypeOf(client)).forEach(functionName => {
     const originalFunction = client[functionName];
 
-    client[functionName] = (request, callback) => {
+    client[functionName] = (request, options, callback) => {
+      if (options && typeof options === 'function') {
+        callback = options;
+        options = {};
+      }
+      if (!options) {
+        options = {};
+      }
+
       if (callback && typeof callback === 'function') {
-        return originalFunction.call(client, request, (error, response) => {
+        return originalFunction.call(client, request, options, (error, response) => {
           callback(error, response);
         });
       }
 
       return new Promise((resolve, reject) => {
-        originalFunction.call(client, request, (error, response) => {
+        originalFunction.call(client, request, options, (error, response) => {
           if (error) {
             reject(error);
           } else {

--- a/test/index.js
+++ b/test/index.js
@@ -12,7 +12,7 @@ describe('test', () => {
   it('normal thunk function should be ok', done => {
     const client = {};
     Object.setPrototypeOf(client, {
-      rpcA(request, callback) {
+      rpcA(request, options, callback) {
         process.nextTick(() => callback(null, {name: request.user}));
       }
     });
@@ -27,7 +27,7 @@ describe('test', () => {
   it('normal thunk function should be ok with error', done => {
     const client = {};
     Object.setPrototypeOf(client, {
-      rpcA(request, callback) {
+      rpcA(request, options, callback) {
         process.nextTick(() => callback(new Error('error')));
       }
     });
@@ -40,10 +40,29 @@ describe('test', () => {
     });
   });
 
+  it('normal thunk function should pass options ', done => {
+    const client = {};
+    Object.setPrototypeOf(client, {
+      rpcA(request, options, callback) {
+        expect(options).to.be.an.instanceof(Object);
+        expect(options.deadline).to.be.an.instanceof(Date);
+        process.nextTick(() => callback(null, {name: request.user}));
+      }
+    });
+    promisify(client);
+
+    var deadline = new Date(Date.now() + 1000);
+    client.rpcA({user: 'hello'}, {deadline: deadline}, (err, res) => {
+      expect(err).to.be.null;
+      expect(res.name).to.equal('hello');
+      done();
+    });
+  });
+
   it('promise should be ok ', done => {
     const client = {};
     Object.setPrototypeOf(client, {
-      rpcA(request, callback) {
+      rpcA(request, options, callback) {
         process.nextTick(() => callback(null, {name: request.user}));
       }
     });
@@ -60,7 +79,7 @@ describe('test', () => {
   it('promise should be ok with error ', done => {
     const client = {};
     Object.setPrototypeOf(client, {
-      rpcA(request, callback) {
+      rpcA(request, options, callback) {
         process.nextTick(() => callback(new Error('error')));
       }
     });
@@ -73,6 +92,26 @@ describe('test', () => {
       expect(err).to.be.an.instanceof(Error);
       expect(err.message).to.equal('error');
       done();
+    });
+  });
+
+  it('promise should pass options ', done => {
+    const client = {};
+    Object.setPrototypeOf(client, {
+      rpcA(request, options, callback) {
+        expect(options).to.be.an.instanceof(Object);
+        expect(options.deadline).to.be.an.instanceof(Date);
+        process.nextTick(() => callback(null, {name: request.user}));
+      }
+    });
+    promisify(client);
+
+    var deadline = new Date(Date.now() + 1000);
+    client.rpcA({user: 'hello'}, {deadline: deadline}).then(res => {
+      expect(res.name).to.equal('hello');
+      done();
+    }).catch(err => {
+      done(new Error('should not error'));
     });
   });
 });


### PR DESCRIPTION
This patch allows uesrs to pass `options` parameter to the underlying gRPC client.
Options are useful to control how a call is made, e.g. [setting deadlines](https://stackoverflow.com/questions/44323644/setting-timeouts-for-grpc-functions-in-node-js).